### PR TITLE
Station geojson

### DIFF
--- a/nettle/station_set.py
+++ b/nettle/station_set.py
@@ -500,6 +500,14 @@ class StationSet(ABC):
                                               self.STATION_DICT.items())
         self.geo_json_handler.write_geojson_to_file_with_geometry_info(
             geojson, self, **kwargs)
+        # write each stations metadata to its own file to save on retrieval time
+        for station_geojson in geojson['features']:
+            station_filename = station_geojson['properties']['station name'] + '.geojson'
+            station_geojson = {
+                "type": "FeatureCollection",
+                "features": [station_geojson]}
+            self.geo_json_handler.write_geojson_to_file_custom_path(
+                geojson=station_geojson, data_manager=self, file_name=station_filename, **kwargs)
         self.geo_json_handler.remove_geometry_from_geojson(geojson)
         self.geo_json_handler.append_stations_not_in_new_update_to_metadata(
             old_station_metadata, old_stations, geojson)
@@ -617,7 +625,8 @@ class StationSet(ABC):
                 self.log.info(
                     f'Station_id={station_id} Time=\033[93m{(t2 - t1):.2f}\033[0m')
             except FailedStationException as se:
-                self.log.error(f"Update Local Station failed for {station_id}: {str(se)}")
+                self.log.error(
+                    f"Update Local Station failed for {station_id}: {str(se)}")
 
         # All stations are up to date, no need to update so return False
         return self.update_verify(data)
@@ -713,7 +722,8 @@ class StationSet(ABC):
                 self.log.info(
                     f'Station_id={station_id} Time=\033[93m{(t2 - t1):.2f}\033[0m')
             except FailedStationException as se:
-                self.log.error(f"Parse Station failed for {station_id}: {str(se)}")
+                self.log.error(
+                    f"Parse Station failed for {station_id}: {str(se)}")
 
         self.write_metadata(data, **kwargs)  # write metadata.json
         # write stations.json and stations.geojson

--- a/nettle/utils/geo_json_handler.py
+++ b/nettle/utils/geo_json_handler.py
@@ -9,6 +9,11 @@ class GeoJsonHandler:
         self.file_handler = file_handler
         self.log = log
 
+    def write_geojson_to_file_custom_path(self, geojson, data_manager, file_name, **kwargs):
+        local_store = Local(dataset_manager=data_manager)
+        filepath = local_store.write(file_name, geojson, encoding='utf-8')
+        self.log.info("wrote station geojson metadata to {}".format(filepath))
+
     def write_geojson_to_file_with_geometry_info(self, geojson, data_manager, **kwargs):
         local_store = Local(dataset_manager=data_manager)
         file_name = MetadataHandler.STATION_METADATA_FILE_NAME.replace(

--- a/nettle/utils/store.py
+++ b/nettle/utils/store.py
@@ -122,6 +122,8 @@ class S3(StoreInterface):
         local_path = self.dm.file_handler.output_path()
         s3_path = self.folder_outpath()
 
+        print(local_path, s3_path)
+
         try:
             filesystem.put(local_path, s3_path, recursive=True)
             return s3_path
@@ -281,7 +283,8 @@ class Local(StoreInterface):
             directory = self.custom_latest_metadata_path
         else:
             directory = self.folder_path
-        metadata_file = self.metadata_by_filesystem(directory=directory, path=path)
+        metadata_file = self.metadata_by_filesystem(
+            directory=directory, path=path)
         if metadata_file is None:
             self.dm.log.warn(f"old metadata could not be found")
         else:

--- a/nettle/utils/store.py
+++ b/nettle/utils/store.py
@@ -122,8 +122,6 @@ class S3(StoreInterface):
         local_path = self.dm.file_handler.output_path()
         s3_path = self.folder_outpath()
 
-        print(local_path, s3_path)
-
         try:
             filesystem.put(local_path, s3_path, recursive=True)
             return s3_path


### PR DESCRIPTION
Allow geojsons to be written with a filepath, this allows us to write station by station geojson whereas before the single 'stations.geojson' file was too large to process on the API